### PR TITLE
更正WebSocket中Caddy配置文件的localhost拼写错误问题...

### DIFF
--- a/advanced/websocket.md
+++ b/advanced/websocket.md
@@ -119,7 +119,7 @@ server {
 ### Caddy 配置
 
 ```
-caddy serveraddr.com
+serveraddr.com
 {
   log ./caddy.log
   proxy / localhost:10000 {

--- a/advanced/websocket.md
+++ b/advanced/websocket.md
@@ -122,7 +122,7 @@ server {
 caddy serveraddr.com
 {
   log ./caddy.log
-  proxy / locaohost:10000 {
+  proxy / localhost:10000 {
     websocket
     header_upstream -Origin
   }


### PR DESCRIPTION
小修小补, 感谢v2ray主群中网友的提醒