### PR TITLE
correct server's json when using nginx as a websocket server.

### DIFF
--- a/advanced/wss_and_web.md
+++ b/advanced/wss_and_web.md
@@ -26,7 +26,10 @@ V2Ray 的不依赖其它软件，只是能与其搭配使用而已，没有它�
       ]
     },
     "streamSettings":{
-      "network":"ws"
+      "network":"ws",
+      "wsSettings": {
+      "path": "/ray"
+      }
     }
   },
   "outbound": {
@@ -113,6 +116,7 @@ serveraddr.com
   }
 }
 ```
+### 注意：较低版本的nginx的location需要写为 /ray/ 才能正常工作
 
 - 如果在设置完成之后不能成功使用，可能是由于 SElinux 机制(如果你是 CentOS 7 的用户请特别留意 SElinux 这一机制)阻止了 Nginx 转发向内网的数据。如果是这样的话，在 V2Ray 的日志里不会有访问信息，在 Nginx 的日志里会出现大量的 "Permission Denied" 字段，要解决这一问题需要在终端下键入以下命令：
   ```


### PR DESCRIPTION
经过一晚上的排查，终于找出了无法连接的问题是 server 的 json streamsetting 中没有 配置 "path": "/ray"