### PR TITLE
去掉nginx配置中重复的proxy_set_header Host $http_host;

### DIFF
--- a/advanced/wss_and_web.md
+++ b/advanced/wss_and_web.md
@@ -69,7 +69,6 @@ server {
         
         # Show realip in v2ray access.log
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 }


### PR DESCRIPTION
https://github.com/v2ray/v2ray-core/issues/1588