### PR TITLE
Add reload and stop executions to tproxy service

### DIFF
--- a/app/tproxy.md
+++ b/app/tproxy.md
@@ -278,6 +278,9 @@ iptables -t mangle -A OUTPUT -j V2RAY_MASK
   Type=oneshot
   #注意分号前后要有空格
   ExecStart=/sbin/ip rule add fwmark 1 table 100 ; /sbin/ip route add local 0.0.0.0/0 dev lo table 100 ; /sbin/iptables-restore /etc/iptables/rules.v4
+  ExecReload=/sbin/iptables-restore /etc/iptables/rules.v4
+  ExecStop=/sbin/ip rule delete fwmark 1 table 100 ; /sbin/ip route delete local 0.0.0.0/0 dev lo table 100 ; /usr/lib/systemd/scripts/iptables-flush
+  RemainAfterExit=yes
 
   [Install]
   WantedBy=multi-user.target


### PR DESCRIPTION
This version should allow user to run `systemctl stop tproxyrule.service` and
`systemctl start tproxyrule.service` to debug network.